### PR TITLE
MapScript Notebook Updates and Fixes

### DIFF
--- a/Mapserver/mapscript_quickstart.ipynb
+++ b/Mapserver/mapscript_quickstart.ipynb
@@ -24,8 +24,6 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "#sys.path.append(\"/rofs/usr/lib/python2.7/dist-packages\") # temporary hack for OSGeoLive\n",
-    "\n",
     "import os\n",
     "import mapscript\n",
     "from IPython.display import Image\n",
@@ -33,7 +31,7 @@
     "#demo_fld = os.getenv(\"MAPSERVER_DEMO\")\n",
     "#mapfile = os.path.join(demo_fld, \"itasca.map\")\n",
     "\n",
-    "#osgeolive 13 \n",
+    "#osgeolive \n",
     "fname = '/usr/local/share/mapserver/demos/itasca/itasca.map'\n",
     "map = mapscript.mapObj(fname)"
    ]
@@ -65,37 +63,10 @@
    "metadata": {},
    "source": [
     "## Drawing Maps\n",
-    "MapScript can be used to create an image file. The draw method\n",
-    "returns an imageObj which can be saved to a filename on disk. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import tempfile\n",
-    "# before creating images let's set the working directory to the temp folder\n",
-    "os.chdir(tempfile.gettempdir()) \n",
     "\n",
-    "output_file = \"map.png\"\n",
-    "image = map.draw()\n",
-    "image.save(output_file)\n",
-    "Image(filename=output_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The map image above doesn't contain all the layers in the Mapfile. \n",
-    "This can be because they are set to hidden by default using ```LAYER STATUS OFF```.\n",
-    "\n",
-    "To turn on these layers and create a more interesting map, we \n",
-    "can loop through the layers again and set their ```STATUS``` to ```ON```. \n",
-    "We can then use the ```isVisible``` method to check if the layer will\n",
-    "be drawn onto the map. "
+    "Before we draw a map, we need to turn on some map layers, or the output image will be empty. \n",
+    "To turn on layers we can loop through the layers again and set their ```LAYER STATUS``` to ```ON```. \n",
+    "We can then use the ```isVisible``` method to check if the layer will be drawn onto the map. "
    ]
   },
   {
@@ -120,7 +91,7 @@
     "The *ctyrdln3* and *ctyrdln3_anno* layers are both hidden because of the ```MAXSCALE 300000```\n",
     "layer setting. \n",
     "\n",
-    "Now we can now draw the map again with the newly visible layers. "
+    "Now we have set layers to be visible MapScript can be used to create an image file. The ```draw``` method returns an imageObj which can be saved to a filename on disk."
    ]
   },
   {
@@ -129,7 +100,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_file = \"map_full.png\"\n",
+    "import tempfile\n",
+    "# before creating images let's set the working directory to the temp folder\n",
+    "os.chdir(tempfile.gettempdir()) \n",
+    "\n",
+    "output_file = \"map.png\"\n",
     "image = map.draw()\n",
     "image.save(output_file)\n",
     "Image(filename=output_file)"
@@ -181,7 +156,9 @@
     "results = qry_layer.getResults()\n",
     "assert results.numresults == 1 # as we did a single query (using MS_SINGLE) there should be only one result\n",
     "result = results.getResult(0)\n",
-    "Image(filename=output_file)"
+    "print(result)\n",
+    "# get the shape index of the result\n",
+    "print(result.shapeindex)"
    ]
   },
   {
@@ -233,15 +210,15 @@
     "\n",
     "print(fields)\n",
     "props = zip(fields, values)  # join fields to values\n",
-    "print(props)"
+    "print(props)\n",
+    "print(list(props))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also create a map showing the query results: \n",
-    "*Note the imageObj is broken for Python MapScript 7.0, but is fixed in 7.2*"
+    "We can also create a map showing the query results: "
    ]
   },
   {
@@ -313,10 +290,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use the msIO methods to capture the response the request\n",
+    "We use the ```msIO``` methods to capture the response the request\n",
     "that is sent to ```stdout```. \n",
     "The response is typically an HTTP response with HTTP content headers. \n",
-    "We can strip these out using MapScript"
+    "We can strip these out using MapScript. "
    ]
   },
   {
@@ -331,7 +308,11 @@
     "# remove the content type header from the XML\n",
     "mapscript.msIO_stripStdoutBufferContentHeaders() # Strip all Content-* headers\n",
     "result = mapscript.msIO_getStdoutBufferBytes()\n",
-    "print(result)"
+    "\n",
+    "# pretty print the XML results\n",
+    "import xml.dom.minidom\n",
+    "xml = xml.dom.minidom.parseString(result)\n",
+    "print(xml.toprettyxml(indent=\" \", newl=''))"
    ]
   },
   {
@@ -397,8 +378,8 @@
    "metadata": {},
    "source": [
     "Thanks for working through this notebook! For more information on MapScript\n",
-    "please see the [MapScript documentation](https://mapserver.org/mapscript/introduction.html). \n",
-    "Additional Python examples can be found in the [MapServer GitHub repository](https://github.com/mapserver/mapserver/tree/master/mapscript/python/examples)"
+    "please see the [MapScript documentation](https://mapserver.org/mapscript/index.html). \n",
+    "Additional Python examples can be found in the [MapServer GitHub repository](https://github.com/MapServer/MapServer/tree/main/src/mapscript/python/examples)"
    ]
   },
   {


### PR DESCRIPTION
Changes to the MapScript notebook:

- Remove a few Python 2 hacks
- Remove the draw example that creates an empty map
- Correctly display OGC XML responses
- Fix a couple of URLs